### PR TITLE
🎙️ Integrate recording system with existing OutputWorker architecture

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -8,6 +8,7 @@ version = "0.1.0"
 dependencies = [
  "alsa 0.7.1",
  "anyhow",
+ "async-trait",
  "base64 0.21.7",
  "chrono",
  "colored",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ serde_json = "1"
 reqwest = { version = "0.11", features = ["json", "stream"] }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
+async-trait = "0.1"
 anyhow = "1"
 thiserror = "1"
 tracing = "0.1"


### PR DESCRIPTION
**Major Integration**: Recording now leverages the existing OutputWorker infrastructure instead of creating a parallel system, ensuring consistent audio processing and proper resource management.

## Key Changes

### 🔧 **Architecture Integration**
- **Recording uses existing OutputWorker**: No more duplicate audio processing logic
- **RTRB queue bridge**: OutputWorker → RTRB queue → RecordingService
- **Single audio pipeline**: Both hardware output and recording share same processing
- **Enforced single recording**: Only one recording allowed at a time

### 🎯 **Command Orchestration** (`recording.rs`)
- **3-step recording start**:
  1. Create OutputWorker + RTRB queue via audio command
  2. Start RecordingService with RTRB consumer
  3. Proper cleanup on failure (prevents resource leaks)
- **2-step recording stop**:
  1. Stop RecordingService (close files)
  2. Remove OutputWorker from pipeline (stop audio processing)

### 🔄 **Service Refactor** (`recording_service.rs`)
- **RTRB consumer**: Replaced `tokio::broadcast::Receiver` with `rtrb::Consumer<f32>`
- **Efficient batch processing**: Drains available samples, yields CPU when empty
- **Maintained existing**: File writing, metadata, silence detection all unchanged

### 🎛️ **Pipeline Coordination** (`isolated_audio_manager.rs`)
- **Added recording commands**: `StartRecording` and `StopRecording`
- **OutputWorker lifecycle**: Creates/destroys recording OutputWorkers on demand
- **Resource management**: Proper cleanup via `audio_pipeline.remove_output_device()`
- **Single output tracking**: Recording treated as another output device

## 🐛 **Critical Bug Fixes**

### **Resource Leak Fix**
- **Problem**: OutputWorker continued running after recording stopped
- **Symptom**: `WARN ⚠️ OUTPUT_WORKER: recording_output RTRB queue full, dropping samples`
- **Solution**: Properly call `remove_output_device()` to stop OutputWorker thread

### **Failure Cleanup**
- **Problem**: Recording validation failures left orphaned OutputWorkers
- **Solution**: Cleanup OutputWorker when RecordingService fails to start

## 🏗️ **Technical Benefits**

✅ **Eliminates code duplication** - Single audio processing path ✅ **Consistent audio quality** - Same resampling/effects for all outputs ✅ **Proper resource management** - OutputWorkers cleaned up on stop/failure ✅ **Lock-free audio flow** - RTRB queues prevent audio thread blocking ✅ **Maintainable architecture** - Clear separation between processing and I/O

🎙️ Generated with [Claude Code](https://claude.ai/code)