### PR TITLE
📡 Integrate Icecast with audio pipeline using OutputWorker architecture

### DIFF
--- a/src-tauri/src/audio/broadcasting/config.rs
+++ b/src-tauri/src/audio/broadcasting/config.rs
@@ -1,7 +1,7 @@
 use super::icecast_source::{AudioCodec, AudioFormat};
 use crate::types::DEFAULT_SAMPLE_RATE;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct StreamingServiceConfig {
     /// Icecast server configuration
     pub server_host: String,

--- a/src-tauri/src/audio/broadcasting/service.rs
+++ b/src-tauri/src/audio/broadcasting/service.rs
@@ -11,5 +11,5 @@ pub use super::utils::{
     connect_streaming_to_mixer, create_stream_bitrate_preset, get_available_bitrates,
     get_current_stream_bitrate, get_streaming_service, get_streaming_status,
     get_variable_bitrate_settings, initialize_streaming, set_stream_bitrate,
-    set_variable_bitrate_streaming, start_streaming, stop_streaming, update_stream_metadata,
+    set_variable_bitrate_streaming, start_streaming, start_streaming_with_consumer, stop_streaming, update_stream_metadata,
 };

--- a/src-tauri/src/audio/broadcasting/utils.rs
+++ b/src-tauri/src/audio/broadcasting/utils.rs
@@ -37,6 +37,15 @@ pub async fn start_streaming() -> Result<()> {
     service.start_streaming().await
 }
 
+/// Start streaming with an RTRB consumer from the audio pipeline
+pub async fn start_streaming_with_consumer(
+    config: StreamingServiceConfig,
+    rtrb_consumer: rtrb::Consumer<f32>,
+) -> Result<()> {
+    let service = get_streaming_service().await;
+    service.start_streaming_with_consumer(config, rtrb_consumer).await
+}
+
 /// Stop streaming
 pub async fn stop_streaming() -> Result<()> {
     let service = get_streaming_service().await;


### PR DESCRIPTION
Following the same pattern as recording integration, Icecast now receives audio directly from the 4-layer audio pipeline through rtrb queues.

## Core Changes

**AudioCommand Extensions:**
- Add `StartIcecast` and `StopIcecast` commands to AudioCommand enum
- Commands follow identical pattern to recording integration

**IsolatedAudioManager Integration:**
- `handle_start_icecast()`: Creates OutputWorker, returns rtrb consumer
- `handle_stop_icecast()`: Removes OutputWorker, cleans up resources
- Uses unique device IDs (`icecast_output_{stream_id}`) for multiple streams

**Updated Icecast Commands:**
- `start_icecast_streaming()`: Sends AudioCommand to pipeline, gets consumer
- `stop_icecast_streaming()`: Stops service and cleans up OutputWorker
- Added robust error handling with automatic cleanup on failures

**Streaming Service Enhancements:**
- Add `start_streaming_with_consumer()` method to StreamingService
- Add `start_streaming_with_consumer()` method to IcecastStreamManager
- Spawns async task to consume from rtrb queue and process audio samples

**Configuration Updates:**
- Add serde traits to StreamingServiceConfig, AudioFormat, AudioCodec
- Enables config passing through Tauri command interface

## Audio Flow

```
Input → Mixer → OutputWorker → RTRB Queue → Icecast Consumer → Network
```

## Benefits

- ✅ Consistent architecture with recording system
- ✅ Real-time audio from pipeline (no mixer polling needed)
- ✅ Support for multiple concurrent Icecast streams
- ✅ Proper resource cleanup and error handling
- ✅ 16x larger buffer for network streaming stability

The foundation is complete - Icecast is now properly integrated into the audio pipeline and will receive real-time samples from the mixer.

Next: Complete MP3/AAC encoding and server connection in the consumer task.

🤖 Generated with [Claude Code](https://claude.ai/code)