### PR TITLE
🎚️ Fix pan effect by handling interleaved stereo audio correctly

### DIFF
--- a/src-tauri/src/audio/effects/default_effects_chain.rs
+++ b/src-tauri/src/audio/effects/default_effects_chain.rs
@@ -66,22 +66,18 @@ impl DefaultAudioEffectsChain {
         self.solo
     }
 
-    pub fn process_stereo(&self, left: &mut [f32], right: &mut [f32], any_channel_solo: bool) {
+    pub fn process_stereo_interleaved(&self, samples: &mut [f32], any_channel_solo: bool) {
         if self.muted || (any_channel_solo && !self.solo) {
-            left.fill(0.0);
-            right.fill(0.0);
+            samples.fill(0.0);
             return;
         }
 
         let left_gain = self.gain * if self.pan <= 0.0 { 1.0 } else { 1.0 - self.pan };
         let right_gain = self.gain * if self.pan >= 0.0 { 1.0 } else { 1.0 + self.pan };
 
-        for sample in left.iter_mut() {
-            *sample *= left_gain;
-        }
-
-        for sample in right.iter_mut() {
-            *sample *= right_gain;
+        for i in 0..(samples.len() / 2) {
+            samples[i * 2] *= left_gain;
+            samples[i * 2 + 1] *= right_gain;
         }
     }
 

--- a/src-tauri/src/audio/mixer/pipeline/input_worker.rs
+++ b/src-tauri/src/audio/mixer/pipeline/input_worker.rs
@@ -318,9 +318,7 @@ impl InputWorker {
                 let any_solo = any_channel_solo.load(std::sync::atomic::Ordering::Relaxed);
                 if let Ok(effects) = default_effects.lock() {
                     if processing_channels == 2 {
-                        let mid_point = effects_processed.len() / 2;
-                        let (left, right) = effects_processed.split_at_mut(mid_point);
-                        effects.process_stereo(left, right, any_solo);
+                        effects.process_stereo_interleaved(&mut effects_processed, any_solo);
                     } else {
                         effects.process_mono(&mut effects_processed, any_solo);
                     }


### PR DESCRIPTION
The pan control was causing audio corruption and not actually panning because it assumed non-interleaved stereo format (all left samples, then all right), but our audio pipeline uses interleaved format ([L, R, L, R, ...]).

**Root Cause:**
In `input_worker.rs`, the code was splitting the buffer at the midpoint:
```rust
let mid_point = effects_processed.len() / 2;
let (left, right) = effects_processed.split_at_mut(mid_point);
```

With interleaved audio `[L1, R1, L2, R2, L3, R3, L4, R4]`:
- First "half": `[L1, R1, L2, R2]` (mixed L+R, not just left!)
- Second "half": `[L3, R3, L4, R4]` (mixed L+R, not just right!)

This caused:
- **Audio corruption**: Different gains applied to alternating samples
- **No panning effect**: Both channels present in both halves

**Solution:**
Renamed `process_stereo()` to `process_stereo_interleaved()` and updated it to process interleaved stereo directly:
```rust
for i in 0..(samples.len() / 2) {
    samples[i * 2] *= left_gain;      // Even indices = left channel
    samples[i * 2 + 1] *= right_gain;  // Odd indices = right channel
}
```

Now pan correctly:
- Pan left (-1.0): left_gain=1.0, right_gain=0.0
- Pan center (0.0): left_gain=1.0, right_gain=1.0
- Pan right (+1.0): left_gain=0.0, right_gain=1.0

**Testing:**
- ✅ Pan left silences right channel, preserves left
- ✅ Pan right silences left channel, preserves right
- ✅ Pan center applies equal gain to both channels
- ✅ No audio artifacts at any pan position
- ✅ Gain, mute, solo continue working correctly

Fixes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)