### PR TITLE
🔧 Remove soft delete pattern and fix mute on application load

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "logs:filter": "bash scripts/filter_logs.sh logs/output.log --f \"$KEYWORDS\" logs/filtered.log && cat logs/filtered.log",
     "logs:clean": "rm  -f logs/output.log && rm -f logs/filtered.log",
     "tauri": "RUSTFLAGS=\"-A warnings\" tauri",
-    "tauri:dev": "clear && pnpm logs:clean && src-swift/build.sh && pnpm tauri dev 2>&1 | tee -a logs/output.log",
-    "tauri:release": "clear && pnpm logs:clean && src-swift/build.sh && pnpm tauri dev --release 2>&1 | tee -a logs/output.log",
+    "tauri:dev": "clear && pnpm logs:clean && src-swift/build.sh && CARGO_TERM_COLOR=always FORCE_COLOR=1 pnpm tauri dev 2>&1 | tee -a logs/output.log",
+    "tauri:release": "clear && pnpm logs:clean && src-swift/build.sh && CARGO_TERM_COLOR=always FORCE_COLOR=1 pnpm tauri dev --release 2>&1 | tee -a logs/output.log",
     "test": "cargo test  --manifest-path ./src-tauri/Cargo.toml",
     "test:rust": "cargo test --verbose  --manifest-path ./src-tauri/Cargo.toml",
     "test:audio": "cargo test audio  --manifest-path ./src-tauri/Cargo.toml",
@@ -28,14 +28,11 @@
     "rust:fmt:check": "cargo fmt --manifest-path ./src-tauri/Cargo.toml -- --check",
     "rust:clippy": "cargo clippy --all-targets --all-features  --manifest-path ./src-tauri/Cargo.toml",
     "migration": "node -e \"const desc = process.argv[2] || 'migration'; const timestamp = new Date().toISOString().replace(/[-:T]/g, '').slice(0, 14); console.log('Creating migration:', \\`src-tauri/migrations/\\${timestamp}_\\${desc}.sql\\`); require('fs').writeFileSync(\\`src-tauri/migrations/\\${timestamp}_\\${desc}.sql\\`, '-- ' + desc.replace(/_/g, ' ') + '\\\\n\\\\n')\"",
+    "migrate": "cargo sqlx migrate run --source ./src-tauri/migrations --database-url sqlite:$HOME/.sendin_beats/data/sendin_beats.db",
     "quality": "turbo run quality",
     "quality:fix": "turbo run quality:fix",
     "pre-commit": "turbo run pre-commit",
-    "clean": "turbo run clean",
-    "// Legacy aliases for backward compatibility": "",
-    "check": "cargo check  --manifest-path ./src-tauri/Cargo.toml",
-    "fmt": "cargo fmt  --manifest-path ./src-tauri/Cargo.toml",
-    "clippy": "cargo clippy --all-targets --all-features  --manifest-path ./src-tauri/Cargo.toml"
+    "clean": "turbo run clean"
   },
   "dependencies": {
     "@headlessui/react": "^1.7.0",

--- a/src-tauri/migrations/20251008231700_remove_soft_deletes_and_audio_levels.sql
+++ b/src-tauri/migrations/20251008231700_remove_soft_deletes_and_audio_levels.sql
@@ -1,0 +1,86 @@
+-- Remove soft delete pattern and drop audio_device_levels table
+
+-- Drop audio_device_levels table
+DROP TABLE IF EXISTS audio_device_levels;
+
+-- Drop ALL indexes that have WHERE deleted_at clauses
+-- audio_mixer_configurations
+DROP INDEX IF EXISTS idx_mixer_config_active;
+DROP INDEX IF EXISTS idx_mixer_config_name;
+DROP INDEX IF EXISTS idx_mixer_config_type;
+DROP INDEX IF EXISTS idx_mixer_config_session_active;
+DROP INDEX IF EXISTS idx_mixer_config_reusable_ref;
+DROP INDEX IF EXISTS idx_mixer_config_default;
+DROP INDEX IF EXISTS idx_mixer_config_single_active_session;
+DROP INDEX IF EXISTS idx_mixer_config_single_default_reusable;
+
+-- configured_audio_devices
+DROP INDEX IF EXISTS idx_configured_audio_devices_active;
+DROP INDEX IF EXISTS idx_configured_audio_devices_device_id;
+DROP INDEX IF EXISTS idx_configured_audio_devices_input_type;
+
+-- audio_effects_default
+DROP INDEX IF EXISTS idx_audio_effects_default_active;
+
+-- audio_effects_custom
+DROP INDEX IF EXISTS idx_audio_effects_custom_type;
+DROP INDEX IF EXISTS idx_audio_effects_custom_active;
+
+-- recordings (if they exist)
+DROP INDEX IF EXISTS idx_recording_configurations_active;
+DROP INDEX IF EXISTS idx_recording_configurations_name;
+DROP INDEX IF EXISTS idx_recordings_active;
+DROP INDEX IF EXISTS idx_recordings_format;
+DROP INDEX IF EXISTS idx_recordings_artist;
+DROP INDEX IF EXISTS idx_recordings_duration;
+DROP INDEX IF EXISTS idx_recording_output_sequence;
+DROP INDEX IF EXISTS idx_recording_output_active;
+
+-- broadcasts (if they exist)
+DROP INDEX IF EXISTS idx_broadcast_configurations_active;
+DROP INDEX IF EXISTS idx_broadcast_configurations_name;
+DROP INDEX IF EXISTS idx_broadcast_configurations_server;
+DROP INDEX IF EXISTS idx_broadcasts_active;
+DROP INDEX IF EXISTS idx_broadcasts_status;
+DROP INDEX IF EXISTS idx_broadcasts_duration;
+DROP INDEX IF EXISTS idx_broadcasts_active_sessions;
+DROP INDEX IF EXISTS idx_broadcast_output_sequence;
+DROP INDEX IF EXISTS idx_broadcast_output_active;
+
+-- Drop deleted_at columns
+ALTER TABLE audio_mixer_configurations DROP COLUMN deleted_at;
+ALTER TABLE configured_audio_devices DROP COLUMN deleted_at;
+ALTER TABLE audio_effects_default DROP COLUMN deleted_at;
+ALTER TABLE audio_effects_custom DROP COLUMN deleted_at;
+
+-- Recreate important indexes without WHERE deleted_at clauses
+-- audio_mixer_configurations
+CREATE INDEX idx_mixer_config_name ON audio_mixer_configurations(name);
+CREATE INDEX idx_mixer_config_type ON audio_mixer_configurations(configuration_type);
+CREATE INDEX idx_mixer_config_session_active ON audio_mixer_configurations(session_active) WHERE session_active = TRUE;
+CREATE INDEX idx_mixer_config_reusable_ref ON audio_mixer_configurations(reusable_configuration_id) WHERE reusable_configuration_id IS NOT NULL;
+CREATE INDEX idx_mixer_config_default ON audio_mixer_configurations(is_default, configuration_type) WHERE is_default = TRUE;
+CREATE UNIQUE INDEX idx_mixer_config_single_active_session ON audio_mixer_configurations(session_active) WHERE session_active = TRUE;
+CREATE UNIQUE INDEX idx_mixer_config_single_default_reusable ON audio_mixer_configurations(is_default) WHERE is_default = TRUE AND configuration_type = 'reusable';
+
+-- configured_audio_devices
+CREATE INDEX idx_configured_audio_devices_device_id ON configured_audio_devices(device_identifier);
+CREATE INDEX idx_configured_audio_devices_input_type ON configured_audio_devices(is_input, configuration_id);
+
+-- audio_effects_custom
+CREATE INDEX idx_audio_effects_custom_type ON audio_effects_custom(type);
+
+-- recordings (if they exist)
+CREATE INDEX IF NOT EXISTS idx_recording_configurations_name ON recording_configurations(name);
+CREATE INDEX IF NOT EXISTS idx_recordings_format ON recordings(format);
+CREATE INDEX IF NOT EXISTS idx_recordings_artist ON recordings(artist);
+CREATE INDEX IF NOT EXISTS idx_recordings_duration ON recordings(duration_seconds);
+CREATE INDEX IF NOT EXISTS idx_recording_output_sequence ON recording_output(recording_id, chunk_sequence);
+
+-- broadcasts (if they exist)
+CREATE INDEX IF NOT EXISTS idx_broadcast_configurations_name ON broadcast_configurations(name);
+CREATE INDEX IF NOT EXISTS idx_broadcast_configurations_server ON broadcast_configurations(server_url);
+CREATE INDEX IF NOT EXISTS idx_broadcasts_status ON broadcasts(final_status);
+CREATE INDEX IF NOT EXISTS idx_broadcasts_duration ON broadcasts(duration_seconds);
+CREATE INDEX IF NOT EXISTS idx_broadcasts_active_sessions ON broadcasts(start_time, end_time) WHERE end_time IS NULL;
+CREATE INDEX IF NOT EXISTS idx_broadcast_output_sequence ON broadcast_output(broadcast_id, chunk_sequence);

--- a/src-tauri/src/audio/mixer/stream_management/isolated_audio_manager.rs
+++ b/src-tauri/src/audio/mixer/stream_management/isolated_audio_manager.rs
@@ -528,8 +528,11 @@ impl IsolatedAudioManager {
         let (initial_gain, initial_pan, initial_muted, initial_solo) = if let Some(ref db) =
             self.database
         {
-            match crate::db::AudioEffectsDefaultService::find_by_device_id(db.sea_orm(), &device_id)
-                .await
+            match crate::db::AudioEffectsDefaultService::find_by_device_identifier_in_active_config(
+                db.sea_orm(),
+                &device_id,
+            )
+            .await
             {
                 Ok(Some(effects)) => {
                     info!(
@@ -696,8 +699,11 @@ impl IsolatedAudioManager {
         let (initial_gain, initial_pan, initial_muted, initial_solo) = if let Some(ref db) =
             self.database
         {
-            match crate::db::AudioEffectsDefaultService::find_by_device_id(db.sea_orm(), &device_id)
-                .await
+            match crate::db::AudioEffectsDefaultService::find_by_device_identifier_in_active_config(
+                db.sea_orm(),
+                &device_id,
+            )
+            .await
             {
                 Ok(Some(effects)) => {
                     info!(

--- a/src-tauri/src/commands/audio_devices.rs
+++ b/src-tauri/src/commands/audio_devices.rs
@@ -113,7 +113,6 @@ pub async fn safe_switch_input_device(
                     crate::entities::configured_audio_device::Column::DeviceIdentifier
                         .eq(&new_device_id),
                 )
-                .filter(crate::entities::configured_audio_device::Column::DeletedAt.is_null())
                 .one(audio_state.database.sea_orm())
                 .await
                 .map_err(|e| format!("Failed to query existing device: {}", e))?;

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -97,11 +97,17 @@ impl AudioDatabase {
 
         // Create SeaORM connection
         println!("🌊 Initializing SeaORM connection...");
+
+        // Enable SQL logging via environment variable: SENDIN_BEATS_SQL_LOGGING=1
+        let enable_sql_logging =
+            std::env::var("SENDIN_BEATS_SQL_LOGGING").unwrap_or_default() == "1";
+
         let mut opt = ConnectOptions::new(database_url.clone());
         opt.max_connections(10)
             .min_connections(1)
             .connect_timeout(Duration::from_secs(8))
-            .idle_timeout(Duration::from_secs(8));
+            .idle_timeout(Duration::from_secs(8))
+            .sqlx_logging(enable_sql_logging);
 
         let sea_orm_db = Database::connect(opt)
             .await

--- a/src-tauri/src/entities/audio_effects_custom.rs
+++ b/src-tauri/src/entities/audio_effects_custom.rs
@@ -14,7 +14,6 @@ pub struct Model {
     pub parameters: String, // JSON string
     pub created_at: ChronoDateTimeUtc,
     pub updated_at: ChronoDateTimeUtc,
-    pub deleted_at: Option<ChronoDateTimeUtc>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/src-tauri/src/entities/audio_effects_default.rs
+++ b/src-tauri/src/entities/audio_effects_default.rs
@@ -15,7 +15,6 @@ pub struct Model {
     pub solo: bool,
     pub created_at: ChronoDateTimeUtc,
     pub updated_at: ChronoDateTimeUtc,
-    pub deleted_at: Option<ChronoDateTimeUtc>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/src-tauri/src/entities/audio_mixer_configuration.rs
+++ b/src-tauri/src/entities/audio_mixer_configuration.rs
@@ -16,7 +16,6 @@ pub struct Model {
     pub is_default: bool,
     pub created_at: ChronoDateTimeUtc,
     pub updated_at: ChronoDateTimeUtc,
-    pub deleted_at: Option<ChronoDateTimeUtc>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
@@ -69,7 +68,6 @@ impl Model {
             is_default: Set(false),
             created_at: Set(now),
             updated_at: Set(now),
-            deleted_at: Set(None),
         }
     }
 

--- a/src-tauri/src/entities/configured_audio_device.rs
+++ b/src-tauri/src/entities/configured_audio_device.rs
@@ -18,7 +18,6 @@ pub struct Model {
     pub configuration_id: String,
     pub created_at: ChronoDateTimeUtc,
     pub updated_at: ChronoDateTimeUtc,
-    pub deleted_at: Option<ChronoDateTimeUtc>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/src/types/db/audio-effects.types.ts
+++ b/src/types/db/audio-effects.types.ts
@@ -15,7 +15,6 @@ export type AudioEffectsDefault = {
   solo: boolean;
   createdAt: Timestamp; // ISO timestamp
   updatedAt: Timestamp; // ISO timestamp
-  deletedAt?: Timestamp; // ISO timestamp
 };
 
 export const AudioEffectType = ['equalizer', 'limiter', 'compressor'] as const;
@@ -65,5 +64,4 @@ export type AudioEffectsCustom<T extends AudioEffectType = AudioEffectType> = {
   parameters: AudioEffectParameters<T>;
   createdAt: Timestamp; // ISO timestamp
   updatedAt: Timestamp; // ISO timestamp
-  deletedAt?: Timestamp; // ISO timestamp
 };

--- a/src/types/db/audio-mixer-configurations.types.ts
+++ b/src/types/db/audio-mixer-configurations.types.ts
@@ -14,7 +14,6 @@ export type AudioMixerConfiguration = {
   isDefault: boolean; // Only one reusable configuration can be default
   createdAt: Timestamp; // ISO timestamp
   updatedAt: Timestamp; // ISO timestamp
-  deletedAt?: Timestamp; // ISO timestamp, null for active records
 };
 
 export type CreateAudioMixerConfiguration = AsCreationAttributes<AudioMixerConfiguration>;

--- a/src/types/db/broadcasts.types.ts
+++ b/src/types/db/broadcasts.types.ts
@@ -28,7 +28,6 @@ export type BroadcastConfiguration = {
   enableQualityMonitoring: boolean;
   createdAt: Timestamp; // ISO timestamp
   updatedAt: Timestamp; // ISO timestamp
-  deletedAt?: Timestamp; // ISO timestamp
 };
 
 export type Broadcast = {
@@ -74,7 +73,6 @@ export type Broadcast = {
 
   createdAt: Timestamp; // ISO timestamp
   updatedAt: Timestamp; // ISO timestamp
-  deletedAt?: Timestamp; // ISO timestamp
 };
 
 export type BroadcastOutput = {
@@ -88,7 +86,6 @@ export type BroadcastOutput = {
   audioData?: number[]; // Optional: store actual audio data for analysis
   createdAt: Timestamp; // ISO timestamp
   updatedAt: Timestamp; // ISO timestamp
-  deletedAt?: Timestamp; // ISO timestamp
 };
 
 // Broadcasting status types for real-time UI

--- a/src/types/db/configured-audio-devices.types.ts
+++ b/src/types/db/configured-audio-devices.types.ts
@@ -17,7 +17,6 @@ export type ConfiguredAudioDevice = {
   channelNumber: number;
   createdAt: Timestamp; // ISO timestamp
   updatedAt: Timestamp; // ISO timestamp
-  deletedAt?: Timestamp; // ISO timestamp
 };
 
 export type CreateConfiguredAudioDevice = AsCreationAttributes<ConfiguredAudioDevice>;

--- a/src/types/db/recordings.types.ts
+++ b/src/types/db/recordings.types.ts
@@ -24,7 +24,6 @@ export type RecordingConfiguration = {
   bitDepth: number; // 16, 24, or 32
   createdAt: Timestamp; // ISO timestamp
   updatedAt: Timestamp; // ISO timestamp
-  deletedAt?: Timestamp; // ISO timestamp
 };
 
 export type Recording = {
@@ -62,7 +61,6 @@ export type Recording = {
 
   createdAt: Timestamp; // ISO timestamp
   updatedAt: Timestamp; // ISO timestamp
-  deletedAt?: Timestamp; // ISO timestamp
 };
 
 export type RecordingOutput = {
@@ -72,5 +70,4 @@ export type RecordingOutput = {
   outputData: number[]; // Binary audio data as byte array
   createdAt: Timestamp; // ISO timestamp
   updatedAt: Timestamp; // ISO timestamp
-  deletedAt?: Timestamp; // ISO timestamp
 };

--- a/src/types/db/util.ts
+++ b/src/types/db/util.ts
@@ -5,19 +5,16 @@ export type AsCreationAttributes<
     id: Uuid<T>;
     createdAt: Timestamp;
     updatedAt: Timestamp;
-    deletedAt?: Timestamp;
   },
-> = Omit<T, 'id' | 'createdAt' | 'updatedAt' | 'deletedAt'>;
+> = Omit<T, 'id' | 'createdAt' | 'updatedAt'>;
 
 export type AsUpdateAttributes<
   T extends {
     id: Uuid<T>;
     createdAt: Timestamp;
     updatedAt: Timestamp;
-    deletedAt?: Timestamp;
   },
 > = Partial<T> & {
   createdAt?: never;
   updatedAt?: never;
-  deletedAt?: never;
 };


### PR DESCRIPTION
## Database Changes
- Created migration to remove `deleted_at` columns from all tables
- Dropped `audio_device_levels` table (not being used)
- Converted all soft deletes to hard deletes throughout codebase
- Updated entity models to remove `deleted_at` fields

## SQL Logging
- SQL logging now disabled by default
- Configurable via `SENDIN_BEATS_SQL_LOGGING=1` environment variable

## Bug Fixes
- Fixed mute not applying on application load
  - Added `find_by_device_identifier_in_active_config()` method to properly lookup effects by device identifier instead of UUID
  - Audio effects (mute, gain, pan, solo) now correctly apply when devices are initialized

## Other Improvements
- Added `migrate` script to package.json for manual migration runs
- Force color output in tauri:dev/tauri:release scripts when piping to tee
- Updated CLAUDE.md to reflect removal of soft delete pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)